### PR TITLE
Add loading fallback for backend wake-up delay on initial app load

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import { Box, CircularProgress, Typography } from '@mui/material';
 
 export default function Home() {
   const router = useRouter();
@@ -18,6 +19,26 @@ export default function Home() {
 
     router.replace('/dashboard');
   }, [user, loading, router]);
+
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        <CircularProgress />
+        <Typography variant="body1">
+          Waking backend service... this may take a moment.
+        </Typography>
+      </Box>
+    );
+  }
 
   return null;
 }


### PR DESCRIPTION
## Summary

This update improves the user experience on initial application load when the backend service is waking up from inactivity (cold start on Render).

Previously, users would see a blank screen or delayed redirect while the frontend waited for authentication state resolution and backend readiness.

## Changes

- Added a loading fallback state on the root route during authentication initialization
- Prevents blank screen while auth context resolves
- Improves perceived performance during backend cold start
- Ensures smooth redirect flow to `/login`