### PR TITLE
Hide demo reset button for non-admin users

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -34,6 +34,8 @@ export default function DashboardLayout({
   const router = useRouter();
   const theme = useTheme();
   const { logout } = useAuth();
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes('ADMIN');
 
   // Controls visibility of the sidebar on mobile screens
   const [isMobileNavOpen, setIsMobileNavOpen] = React.useState<boolean>(false);
@@ -102,7 +104,7 @@ export default function DashboardLayout({
         showMenuButton={!isDesktop}
         onMenuClick={handleToggleMobileNav}
         onLogout={handleLogout}
-        onResetDemo={handleResetDemo}
+        onResetDemo={isAdmin ? handleResetDemo : undefined}
       />
       <DashboardSidebar
         open={isMobileNavOpen}

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -53,7 +53,7 @@ export interface DashboardHeaderProps {
   /** Callback triggered when the logout button is clicked */
   onLogout: () => void;
   /** Callback triggered when the reset demo button is clicked */
-  onResetDemo: () => void;
+  onResetDemo?: () => void;
 }
 
 /**
@@ -129,15 +129,17 @@ export default function DashboardHeader({
           </Stack>
 
           <Stack direction="row" alignItems="center">
-            <Button
-              color="error"
-              variant="outlined"
-              size="small"
-              onClick={onResetDemo}
-              sx={{ ml: 2 }}
-            >
-              Reset Demo
-            </Button>
+            {onResetDemo && (
+              <Button
+                color="error"
+                variant="outlined"
+                size="small"
+                onClick={onResetDemo}
+                sx={{ ml: 2 }}
+              >
+                Reset Demo
+              </Button>
+            )}
 
             <Button
               color="secondary"


### PR DESCRIPTION
## Summary

This update improves role-based UI behavior by restricting visibility of the "Reset Demo" action to admin users only.

---

## Changes

- Added role check in DashboardLayout using authenticated user context
- Conditionally renders Reset Demo button only for ADMIN users

